### PR TITLE
Read in chunks

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -18,6 +18,9 @@ akka.persistence.r2dbc {
 
     # When live queries return no results. How often to poll db for new rows
     refresh-interval = 3s
+
+    # In-memory buffer holding events when reading from database.
+    buffer-size = 1000
   }
 
 

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -16,6 +16,7 @@ import com.typesafe.config.Config
 @InternalStableApi
 final class QuerySettings(config: Config) {
   val refreshInterval: FiniteDuration = config.getDuration("refresh-interval").asScala
+  val bufferSize: Int = config.getInt("buffer-size")
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcExecutor.scala
@@ -181,6 +181,10 @@ class R2dbcExecutor(connectionFactory: ConnectionFactory, log: Logger)(implicit
     }
   }
 
+  def selectOne[A](logPrefix: String)(statement: Connection => Statement, mapRow: Row => A): Future[Option[A]] = {
+    select(logPrefix)(statement, mapRow).map(_.headOption)(ExecutionContext.parasitic)
+  }
+
   def select[A](
       logPrefix: String)(statement: Connection => Statement, mapRow: Row => A): Future[immutable.IndexedSeq[A]] = {
     val startTime = System.nanoTime()

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -12,7 +12,7 @@
         <appender-ref ref="STDOUT"/>
     </logger>
 
-<!--    <logger name="akka.persistence.r2dbc" level="TRACE" />-->
+    <logger name="akka.persistence.r2dbc" level="TRACE" />
 <!--    <logger name="io.r2dbc.pool" level="DEBUG" />-->
 
 

--- a/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestActors.scala
@@ -14,6 +14,7 @@ object TestActors {
     sealed trait Command
     final case class Persist(payload: Any) extends Command
     final case class PersistWithAck(payload: Any, replyTo: ActorRef[Done]) extends Command
+    final case class PersistAll(payloads: List[Any]) extends Command
     final case class Ping(replyTo: ActorRef[Done]) extends Command
     final case class Stop(replyTo: ActorRef[Done]) extends Command
 
@@ -27,6 +28,8 @@ object TestActors {
               Effect.persist(command.payload)
             case command: PersistWithAck =>
               Effect.persist(command.payload).thenRun(_ => command.replyTo ! Done)
+            case command: PersistAll =>
+              Effect.persist(command.payloads)
             case Ping(replyTo) =>
               replyTo ! Done
               Effect.none

--- a/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/TestConfig.scala
@@ -19,5 +19,6 @@ object TestConfig {
         "akka.persistence.r2dbc.CborSerializable" = jackson-cbor
       }
     }
+    akka.actor.testkit.typed.default-timeout = 10s
     """))
 }


### PR DESCRIPTION
* since each query result is materialized in memory we
  must have a limit on the result set
* ContinousQuery allow for defining the delay and next query
  based on number of elements found in previous query
* Query more when reaching the limit (buffer-size)