### PR TITLE
Read behind current timestamp

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -19,8 +19,12 @@ akka.persistence.r2dbc {
     # When live queries return no results. How often to poll db for new rows
     refresh-interval = 3s
 
+    # Live queries read events up to this duration from the current database time.
+    behind-current-time = 1s
+
     # In-memory buffer holding events when reading from database.
     buffer-size = 1000
+
   }
 
   # postgres or yugabyte

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -35,6 +35,7 @@ final class R2dbcSettings(config: Config) {
 @InternalStableApi
 final class QuerySettings(config: Config) {
   val refreshInterval: FiniteDuration = config.getDuration("refresh-interval").asScala
+  val behindCurrentTime: FiniteDuration = config.getDuration("behind-current-time").asScala
   val bufferSize: Int = config.getInt("buffer-size")
 }
 

--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -23,4 +23,4 @@ CREATE TABLE IF NOT EXISTS event_journal(
   PRIMARY KEY(slice, entity_type_hint, persistence_id, sequence_number)
 );
 
-CREATE INDEX event_journal_slice_idx IF NOT EXISTS ON event_journal(slice, entity_type_hint, db_timestamp);
+CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type_hint, db_timestamp);

--- a/ddl-scripts/create_tables_yugabyte.sql
+++ b/ddl-scripts/create_tables_yugabyte.sql
@@ -23,4 +23,4 @@ CREATE TABLE IF NOT EXISTS event_journal(
   PRIMARY KEY(slice, entity_type_hint, persistence_id, sequence_number)
 );
 
-CREATE INDEX event_journal_slice_idx ON event_journal(slice, entity_type_hint, db_timestamp);
+CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type_hint, db_timestamp);


### PR DESCRIPTION
* because transaction_timestamp() is when the transaction started, not when it was
  committed and therefore it is possible to miss events when reading at the very
  end of the tail
* this is probably not the final (full) solution to this problem, since it's
  hard to know how long the delay should be to be safe
* it's a first quick improvement to that problem, and akka-projection-testing
  is passing with this, which it didn't before

* like eventual consistency delay