### PR TITLE
OffsetStore for TimestampOffset

### DIFF
--- a/ddl-scripts/create_tables_postgres.sql
+++ b/ddl-scripts/create_tables_postgres.sql
@@ -25,6 +25,7 @@ CREATE TABLE IF NOT EXISTS event_journal(
 
 CREATE INDEX IF NOT EXISTS event_journal_slice_idx ON event_journal(slice, entity_type_hint, db_timestamp);
 
+-- DROP TABLE IF EXISTS akka_projection_offset_store;
 
 CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
   projection_name VARCHAR(255) NOT NULL,
@@ -36,7 +37,22 @@ CREATE TABLE IF NOT EXISTS akka_projection_offset_store (
   PRIMARY KEY(projection_name, projection_key)
 );
 
-CREATE INDEX IF NOT EXISTS projection_name_index ON akka_projection_offset_store (projection_name);
+-- DROP TABLE IF EXISTS akka_projection_timestamp_offset_store;
+
+CREATE TABLE IF NOT EXISTS akka_projection_timestamp_offset_store (
+  projection_name VARCHAR(255) NOT NULL,
+  projection_key VARCHAR(255) NOT NULL,
+  persistence_id VARCHAR(255) NOT NULL,
+  sequence_number BIGINT NOT NULL,
+  -- timestamp_offset is the db_timestamp of the original event
+  timestamp_offset timestamp with time zone NOT NULL,
+  -- last_updated is when the offset was stored
+  -- the consumer lag is last_updated - timestamp_offset
+  last_updated timestamp with time zone NOT NULL,
+  PRIMARY KEY(projection_name, projection_key, persistence_id)
+);
+
+-- DROP TABLE IF EXISTS akka_projection_management;
 
 CREATE TABLE IF NOT EXISTS akka_projection_management (
   projection_name VARCHAR(255) NOT NULL,

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -10,10 +10,17 @@ akka.projection.r2dbc {
     # set this to your database schema if applicable, empty by default
     schema = ""
     # the database table name for the offset store
-    table = "akka_projection_offset_store"
+    offset-table = "akka_projection_offset_store"
+
+    # the database table name for the offset store
+    timestamp-offset-table = "akka_projection_timestamp_offset_store"
 
     # the database table name for the projection manangement data
     management-table = "akka_projection_management"
+
+    time-window = 5 minutes
+    evict-interval = 10 seconds
+    delete-interval = 1 minute
   }
 
   # To share connection-factory with akka-persistence-r2dbc (write side) this can

--- a/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -4,33 +4,43 @@
 
 package akka.projection.r2dbc
 
+import java.time.{ Duration => JDuration }
 import akka.actor.typed.ActorSystem
 import com.typesafe.config.Config
-
-final class R2dbcProjectionSettings(config: Config) {
-
-  val schema: Option[String] =
-    Option(config.getString("offset-store.schema")).filterNot(_.trim.isEmpty)
-
-  val table: String = config.getString("offset-store.table")
-
-  val tableWithSchema: String = schema.map("." + _).getOrElse("") + table
-
-  val managementTable: String = config.getString("offset-store.management-table")
-
-  val useConnectionFactory: String = config.getString("use-connection-factory")
-
-  val verboseLoggingEnabled: Boolean = config.getBoolean("debug.verbose-offset-store-logging")
-
-}
 
 object R2dbcProjectionSettings {
 
   val DefaultConfigPath = "akka.projection.r2dbc"
 
-  def apply(config: Config): R2dbcProjectionSettings =
-    new R2dbcProjectionSettings(config)
+  def apply(config: Config): R2dbcProjectionSettings = {
+    R2dbcProjectionSettings(
+      schema = Option(config.getString("offset-store.schema")).filterNot(_.trim.isEmpty),
+      offsetTable = config.getString("offset-store.offset-table"),
+      timestampOffsetTable = config.getString("offset-store.timestamp-offset-table"),
+      managementTable = config.getString("offset-store.management-table"),
+      useConnectionFactory = config.getString("use-connection-factory"),
+      verboseLoggingEnabled = config.getBoolean("debug.verbose-offset-store-logging"),
+      timeWindow = config.getDuration("offset-store.time-window"),
+      evictInterval = config.getDuration("offset-store.evict-interval"),
+      deleteInterval = config.getDuration("offset-store.delete-interval"))
+  }
 
   def apply(system: ActorSystem[_]): R2dbcProjectionSettings =
-    new R2dbcProjectionSettings(system.settings.config.getConfig(DefaultConfigPath))
+    apply(system.settings.config.getConfig(DefaultConfigPath))
+}
+
+// FIXME remove case class, and add `with` methods
+final case class R2dbcProjectionSettings(
+    schema: Option[String],
+    offsetTable: String,
+    timestampOffsetTable: String,
+    managementTable: String,
+    useConnectionFactory: String,
+    verboseLoggingEnabled: Boolean,
+    timeWindow: JDuration,
+    evictInterval: JDuration,
+    deleteInterval: JDuration) {
+  val offsetTableWithSchema: String = schema.map("." + _).getOrElse("") + offsetTable
+  val timestampOffsetTableWithSchema: String = schema.map("." + _).getOrElse("") + timestampOffsetTable
+  val managementTableWithSchema: String = schema.map("." + _).getOrElse("") + managementTable
 }

--- a/projection/src/test/resources/logback-test.xml
+++ b/projection/src/test/resources/logback-test.xml
@@ -14,6 +14,7 @@
 
     <logger name="akka.projection.r2dbc" level="DEBUG" />
 <!--    <logger name="akka.persistence.r2dbc" level="TRACE" />-->
+    <logger name="io.r2dbc.postgresql.QUERY" level="DEBUG" />
 <!--    <logger name="io.r2dbc.pool" level="DEBUG" />-->
 
 

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcOffsetStoreSpec.scala
@@ -38,7 +38,7 @@ class R2dbcOffsetStoreSpec
   private def createOffsetStore(projectionId: ProjectionId) =
     new R2dbcOffsetStore(projectionId, system, settings, r2dbcExecutor, clock)
 
-  private val table = settings.tableWithSchema
+  private val table = settings.offsetTableWithSchema
 
   private implicit val ec: ExecutionContext = system.executionContext
 
@@ -143,6 +143,16 @@ class R2dbcOffsetStoreSpec
       offsetStore.saveOffset(timeUuidOffset).futureValue
       val offset = offsetStore.readOffset[TimeBasedUUID]()
       offset.futureValue shouldBe Some(timeUuidOffset)
+    }
+
+    s"save and retrieve offsets of unknown custom serializable type" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      val customOffset = "abc"
+      offsetStore.saveOffset(customOffset).futureValue
+      val offset = offsetStore.readOffset[TimeBasedUUID]()
+      offset.futureValue shouldBe Some(customOffset)
     }
 
     s"save and retrieve MergeableOffset" in {

--- a/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/R2dbcTimestampOffsetStoreSpec.scala
@@ -1,0 +1,252 @@
+/*
+ * Copyright (C) 2021 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.r2dbc
+
+import java.time.Instant
+import java.time.{ Duration => JDuration }
+
+import scala.concurrent.ExecutionContext
+
+import akka.actor.testkit.typed.scaladsl.LogCapturing
+import akka.actor.testkit.typed.scaladsl.ScalaTestWithActorTestKit
+import akka.actor.typed.ActorSystem
+import akka.persistence.r2dbc.query.TimestampOffset
+import akka.projection.ProjectionId
+import akka.projection.internal.ManagementState
+import akka.projection.r2dbc.internal.R2dbcOffsetStore
+import org.scalatest.wordspec.AnyWordSpecLike
+import org.slf4j.LoggerFactory
+
+class R2dbcTimestampOffsetStoreSpec
+    extends ScalaTestWithActorTestKit(TestConfig.config)
+    with AnyWordSpecLike
+    with TestDbLifecycle
+    with TestData
+    with LogCapturing {
+
+  override def typedSystem: ActorSystem[_] = system
+
+  private val clock = new TestClock
+  def tick(): Unit = clock.tick(JDuration.ofMillis(1))
+
+  private val log = LoggerFactory.getLogger(getClass)
+
+  private val settings = R2dbcProjectionSettings(testKit.system)
+
+  private def createOffsetStore(projectionId: ProjectionId, customSettings: R2dbcProjectionSettings = settings) =
+    new R2dbcOffsetStore(projectionId, system, customSettings, r2dbcExecutor)
+
+  private val table = settings.timestampOffsetTableWithSchema
+
+  private implicit val ec: ExecutionContext = system.executionContext
+
+  "The R2dbcOffsetStore for TimestampOffset" must {
+
+    s"update TimestampOffset with one entry" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L))
+      offsetStore.saveOffset(offset1).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(offset1)
+
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 4L))
+      offsetStore.saveOffset(offset2).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      readOffset2.futureValue shouldBe Some(offset2) // yep, saveOffset overwrites previous
+    }
+
+    s"update TimestampOffset with several entries" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(offset1).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(offset1)
+
+      tick()
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 4L, "p3" -> 6L, "p4" -> 9L))
+      offsetStore.saveOffset(offset2).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      // p2 is not included in read offset because it wasn't updated and has earlier timestamp
+      readOffset2.futureValue shouldBe Some(offset2)
+    }
+
+    s"update TimestampOffset when same timestamp" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 1L, "p3" -> 5L))
+      offsetStore.saveOffset(offset1).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(offset1)
+
+      // not tick, same timestamp
+      val offset2 = TimestampOffset(clock.instant(), Map("p2" -> 2L, "p4" -> 9L))
+      offsetStore.saveOffset(offset2).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      // all should be included since same timestamp
+      val expectedOffset2 = TimestampOffset(clock.instant(), Map("p1" -> 3L, "p2" -> 2L, "p3" -> 5L, "p4" -> 9L))
+      readOffset2.futureValue shouldBe Some(expectedOffset2)
+
+      // saving new with later timestamp
+      tick()
+      val offset3 = TimestampOffset(clock.instant(), Map("p1" -> 4L))
+      offsetStore.saveOffset(offset3).futureValue
+      val readOffset3 = offsetStore.readOffset[TimestampOffset]()
+      // then it should only contain that entry
+      readOffset3.futureValue shouldBe Some(offset3)
+    }
+
+    s"not update when earlier seqNr" in {
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      tick()
+      val offset1 = TimestampOffset(clock.instant(), Map("p1" -> 3L))
+      offsetStore.saveOffset(offset1).futureValue
+      val readOffset1 = offsetStore.readOffset[TimestampOffset]()
+      readOffset1.futureValue shouldBe Some(offset1)
+
+      clock.setInstant(clock.instant().minusMillis(1))
+      val offset2 = TimestampOffset(clock.instant(), Map("p1" -> 2L))
+      offsetStore.saveOffset(offset2).futureValue
+      val readOffset2 = offsetStore.readOffset[TimestampOffset]()
+      readOffset2.futureValue shouldBe Some(offset1) // keeping offset1
+    }
+
+    s"evict old records" in {
+      val projectionId = genRandomProjectionId()
+      val evictSettings = settings.copy(timeWindow = JDuration.ofSeconds(100), evictInterval = JDuration.ofSeconds(10))
+      import evictSettings._
+      val offsetStore = createOffsetStore(projectionId, evictSettings)
+
+      val startTime = Instant.now()
+      log.debug("Start time [{}]", startTime)
+
+      offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map("p2" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map("p3" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(evictInterval), Map("p4" -> 1L))).futureValue
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(1)), Map("p4" -> 1L)))
+        .futureValue
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(2)), Map("p5" -> 1L)))
+        .futureValue
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(evictInterval).plus(JDuration.ofSeconds(3)), Map("p6" -> 1L)))
+        .futureValue
+      offsetStore.getState().size shouldBe 6
+
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.minusSeconds(10)), Map("p7" -> 1L))).futureValue
+      offsetStore.getState().size shouldBe 7 // nothing evicted yet
+
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).minusSeconds(3)), Map("p8" -> 1L)))
+        .futureValue
+      offsetStore.getState().size shouldBe 8 // still nothing evicted yet
+
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(1)), Map("p8" -> 2L)))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set("p5", "p6", "p7", "p8")
+
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(timeWindow.plus(evictInterval).plusSeconds(20)), Map("p8" -> 3L)))
+        .futureValue
+      offsetStore.getState().byPid.keySet shouldBe Set("p7", "p8")
+    }
+
+    s"delete old records" in {
+      val projectionId = genRandomProjectionId()
+      val deleteSettings = settings.copy(timeWindow = JDuration.ofSeconds(100))
+      import deleteSettings._
+      val offsetStore = createOffsetStore(projectionId, deleteSettings)
+
+      val startTime = Instant.now()
+      log.debug("Start time [{}]", startTime)
+
+      offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(JDuration.ofSeconds(1)), Map("p2" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(JDuration.ofSeconds(2)), Map("p3" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(JDuration.ofSeconds(3)), Map("p4" -> 1L))).futureValue
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0
+      offsetStore.readOffset().futureValue // this will load from database
+      offsetStore.getState().size shouldBe 4
+
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.minusSeconds(2)), Map("p5" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.minusSeconds(1)), Map("p6" -> 1L))).futureValue
+      // nothing deleted yet
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 0
+      offsetStore.readOffset().futureValue // this will load from database
+      offsetStore.getState().size shouldBe 6
+
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.plusSeconds(1)), Map("p7" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.plusSeconds(2)), Map("p8" -> 1L))).futureValue
+      offsetStore.deleteOldTimestampOffsets().futureValue shouldBe 2
+      offsetStore.readOffset().futureValue // this will load from database
+      offsetStore.getState().byPid.keySet shouldBe Set("p3", "p4", "p5", "p6", "p7", "p8")
+    }
+
+    s"periodically delete old records" in {
+      val projectionId = genRandomProjectionId()
+      val deleteSettings =
+        settings.copy(timeWindow = JDuration.ofSeconds(100), deleteInterval = JDuration.ofMillis(500))
+      import deleteSettings._
+      val offsetStore = createOffsetStore(projectionId, deleteSettings)
+
+      val startTime = Instant.now()
+      log.debug("Start time [{}]", startTime)
+
+      offsetStore.saveOffset(TimestampOffset(startTime, Map("p1" -> 1L))).futureValue
+      offsetStore.saveOffset(TimestampOffset(startTime.plus(timeWindow.plusSeconds(1)), Map("p2" -> 1L))).futureValue
+      eventually {
+        offsetStore.readOffset().futureValue // this will load from database
+        offsetStore.getState().byPid.keySet shouldBe Set("p2")
+      }
+
+      offsetStore
+        .saveOffset(TimestampOffset(startTime.plus(timeWindow.multipliedBy(2).plusSeconds(2)), Map("p3" -> 1L)))
+        .futureValue
+      eventually {
+        offsetStore.readOffset().futureValue // this will load from database
+        offsetStore.getState().byPid.keySet shouldBe Set("p3")
+      }
+    }
+
+    s"clear offset" in {
+      pending // FIXME not implemented yet
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      offsetStore.saveOffset(3L).futureValue
+      offsetStore.readOffset[Long]().futureValue shouldBe Some(3L)
+
+      offsetStore.clearOffset().futureValue
+      offsetStore.readOffset[Long]().futureValue shouldBe None
+    }
+
+    s"read and save paused" in {
+      pending // FIXME not implemented yet
+      val projectionId = genRandomProjectionId()
+      val offsetStore = createOffsetStore(projectionId)
+
+      offsetStore.readManagementState().futureValue shouldBe None
+
+      offsetStore.savePaused(paused = true).futureValue
+      offsetStore.readManagementState().futureValue shouldBe Some(ManagementState(paused = true))
+
+      offsetStore.savePaused(paused = false).futureValue
+      offsetStore.readManagementState().futureValue shouldBe Some(ManagementState(paused = false))
+    }
+  }
+}

--- a/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
+++ b/projection/src/test/scala/akka/projection/r2dbc/TestDbLifecycle.scala
@@ -20,7 +20,7 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
   def testConfigPath: String = "akka.projection.r2dbc"
 
   lazy val r2dbcSettings: R2dbcProjectionSettings =
-    new R2dbcProjectionSettings(typedSystem.settings.config.getConfig(testConfigPath))
+    R2dbcProjectionSettings(typedSystem.settings.config.getConfig(testConfigPath))
 
   lazy val r2dbcExecutor: R2dbcExecutor = {
     new R2dbcExecutor(
@@ -30,10 +30,16 @@ trait TestDbLifecycle extends BeforeAndAfterAll { this: Suite =>
 
   override protected def beforeAll(): Unit = {
     Await.result(
-      r2dbcExecutor.updateOne("beforeAll delete")(_.createStatement(s"delete from ${r2dbcSettings.table}")),
+      r2dbcExecutor.updateOne("beforeAll delete")(
+        _.createStatement(s"delete from ${r2dbcSettings.offsetTableWithSchema}")),
       10.seconds)
     Await.result(
-      r2dbcExecutor.updateOne("beforeAll delete")(_.createStatement(s"delete from ${r2dbcSettings.managementTable}")),
+      r2dbcExecutor.updateOne("beforeAll delete")(
+        _.createStatement(s"delete from ${r2dbcSettings.timestampOffsetTableWithSchema}")),
+      10.seconds)
+    Await.result(
+      r2dbcExecutor.updateOne("beforeAll delete")(
+        _.createStatement(s"delete from ${r2dbcSettings.managementTableWithSchema}")),
       10.seconds)
     super.beforeAll()
   }


### PR DESCRIPTION
* store TimestampOffset in separate table, with one row per
  persistence_id to keep track of sequence_number
* the pid/seqNr State will be used to filter duplicates
* keep a time window in memory and database
  * db deletes in the background
* consumer lag can be seen from last_updated - timestamp_offset