### PR TITLE
Only accept known expected sequence numbers

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -25,6 +25,8 @@ akka.persistence.r2dbc {
     backtracking {
       enabled = on
       window = 1 minute
+      # Backtracking queries read events up to this duration from the current database time.
+      behind-current-time = 3 seconds
     }
 
     # In-memory buffer holding events when reading from database.

--- a/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/R2dbcSettings.scala
@@ -40,6 +40,7 @@ final class QuerySettings(config: Config) {
   val behindCurrentTime: FiniteDuration = config.getDuration("behind-current-time").asScala
   val backtrackingEnabled: Boolean = config.getBoolean("backtracking.enabled")
   val backtrackingWindow: FiniteDuration = config.getDuration("backtracking.window").asScala
+  val backtrackingBehindCurrentTime: FiniteDuration = config.getDuration("backtracking.behind-current-time").asScala
   val bufferSize: Int = config.getInt("buffer-size")
 }
 

--- a/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcSerializer.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/internal/R2dbcSerializer.scala
@@ -42,6 +42,7 @@ import akka.serialization.SerializerWithStringManifest
   private def offsetToBinary(offset: TimestampOffset): Array[Byte] = {
     val str = new java.lang.StringBuilder
     str.append(offset.timestamp)
+    // readTimestamp not used in serialized
     if (offset.seen.size == 1) {
       // optimized for the normal case
       val pid = offset.seen.head._1
@@ -67,6 +68,7 @@ import akka.serialization.SerializerWithStringManifest
     try {
       val parts = str.split(separator)
       val timestamp = Instant.parse(parts(0))
+      // readTimestamp not used in serialized
       if (parts.length == 3) {
         // optimized for the normal case
         TimestampOffset(timestamp, Map(parts(1) -> parts(2).toLong))

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/JournalDao.scala
@@ -34,6 +34,7 @@ private[r2dbc] object JournalDao {
       persistenceId: String,
       sequenceNr: Long,
       dbTimestamp: Instant,
+      readDbTimestamp: Instant,
       payload: Array[Byte],
       serId: Int,
       serManifest: String,
@@ -205,6 +206,7 @@ private[r2dbc] class JournalDao(journalSettings: R2dbcSettings, connectionFactor
             persistenceId = persistenceId,
             sequenceNr = row.get("sequence_number", classOf[java.lang.Long]),
             dbTimestamp = row.get("db_timestamp", classOf[Instant]),
+            readDbTimestamp = Instant.EPOCH, // not needed here
             payload = row.get("event_payload", classOf[Array[Byte]]),
             serId = row.get("event_ser_id", classOf[java.lang.Integer]),
             serManifest = row.get("event_ser_manifest", classOf[String]),

--- a/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/journal/R2dbcJournal.scala
@@ -92,6 +92,7 @@ final class R2dbcJournal(config: Config, cfgPath: String) extends AsyncWriteJour
             pr.persistenceId,
             pr.sequenceNr,
             JournalDao.EmptyDbTimestamp,
+            JournalDao.EmptyDbTimestamp,
             serialized,
             id,
             manifest,

--- a/core/src/main/scala/akka/persistence/r2dbc/query/TimestampOffset.scala
+++ b/core/src/main/scala/akka/persistence/r2dbc/query/TimestampOffset.scala
@@ -9,13 +9,18 @@ import java.time.Instant
 import akka.persistence.query.Offset
 
 object TimestampOffset {
-  val Zero: TimestampOffset = TimestampOffset(Instant.EPOCH, Map.empty)
+  val Zero: TimestampOffset = TimestampOffset(Instant.EPOCH, Instant.EPOCH, Map.empty)
+
+  def apply(timestamp: Instant, seen: Map[String, Long]): TimestampOffset =
+    TimestampOffset(timestamp, Instant.EPOCH, seen)
 }
 
 /**
  * @param timestamp
- *   microsecond granularity database timestamp
+ *   time when the event was stored, microsecond granularity database timestamp
+ * @param readTimestamp
+ *   time when the event was read, microsecond granularity database timestamp
  * @param seen
  *   List of sequence nrs for every persistence id seen at this timestamp
  */
-final case class TimestampOffset(timestamp: Instant, seen: Map[String, Long]) extends Offset
+final case class TimestampOffset(timestamp: Instant, readTimestamp: Instant, seen: Map[String, Long]) extends Offset

--- a/core/src/test/scala/akka/persistence/r2dbc/internal/SerializerSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/internal/SerializerSpec.scala
@@ -19,17 +19,19 @@ class SerializerSpec extends ScalaTestWithActorTestKit with AnyWordSpecLike with
 
   "SpannerSerializer" must {
     Seq(
-      "TimestampOffset-1" -> TimestampOffset(commitTimestamp, Map.empty),
-      "TimestampOffset-2" -> TimestampOffset(commitTimestamp, Map("pid1" -> 5L)),
-      "TimestampOffset-3" -> TimestampOffset(commitTimestamp, Map("pid1" -> 5L, "pid2" -> 3L, "pid3" -> 7L))).foreach {
-      case (scenario, item) =>
-        s"resolve serializer for $scenario" in {
-          SerializationExtension(system).findSerializerFor(item).getClass should be(classOf[R2dbcSerializer])
-        }
+      "TimestampOffset-1" -> TimestampOffset(commitTimestamp, Instant.EPOCH, Map.empty),
+      "TimestampOffset-2" -> TimestampOffset(commitTimestamp, Instant.EPOCH, Map("pid1" -> 5L)),
+      "TimestampOffset-3" -> TimestampOffset(
+        commitTimestamp,
+        Instant.EPOCH,
+        Map("pid1" -> 5L, "pid2" -> 3L, "pid3" -> 7L))).foreach { case (scenario, item) =>
+      s"resolve serializer for $scenario" in {
+        SerializationExtension(system).findSerializerFor(item).getClass should be(classOf[R2dbcSerializer])
+      }
 
-        s"serialize and de-serialize $scenario" in {
-          verifySerialization(item)
-        }
+      s"serialize and de-serialize $scenario" in {
+        verifySerialization(item)
+      }
     }
   }
 

--- a/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
+++ b/core/src/test/scala/akka/persistence/r2dbc/query/EventsBySliceSpec.scala
@@ -188,10 +188,11 @@ class EventsBySliceSpec
       offset.seen shouldEqual Map(singleEvent.persistenceId -> singleEvent.sequenceNr)
 
       val offsetWithoutSeen = TimestampOffset(offset.timestamp, Map.empty)
-      query
+      val singleEvent2 = query
         .currentEventsBySlices(entityTypeHint, slice, slice, offsetWithoutSeen)
         .runWith(Sink.headOption)
-        .futureValue shouldEqual Some(singleEvent)
+        .futureValue
+      singleEvent2.get.event shouldBe "e-1"
     }
 
     "retrieve from several slices" in new Setup {

--- a/projection/src/main/resources/reference.conf
+++ b/projection/src/main/resources/reference.conf
@@ -21,6 +21,15 @@ akka.projection.r2dbc {
     time-window = 5 minutes
     evict-interval = 10 seconds
     delete-interval = 1 minute
+
+    # Sequence number 1 and numbers that are +1 of previously known are always accepted.
+    # Unknown persistence id is only accepted if the age of the TimestampOffset is greater
+    # than this property. Age is the readTimestamp - timestamp in TimestampOffset.
+    # The purpose is to not emit a later sequence number for a persistence id in case
+    # an earlier event was missed. The backtracking query will emit events again and
+    # those will pass this filter. In other words, new unknown sequence numbers will
+    # be delayed to ensure the ordering guarantee for a persistence id.
+    accept-new-sequence-number-after-age = 3 seconds
   }
 
   # To share connection-factory with akka-persistence-r2dbc (write side) this can

--- a/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
+++ b/projection/src/main/scala/akka/projection/r2dbc/R2dbcProjectionSettings.scala
@@ -22,7 +22,8 @@ object R2dbcProjectionSettings {
       verboseLoggingEnabled = config.getBoolean("debug.verbose-offset-store-logging"),
       timeWindow = config.getDuration("offset-store.time-window"),
       evictInterval = config.getDuration("offset-store.evict-interval"),
-      deleteInterval = config.getDuration("offset-store.delete-interval"))
+      deleteInterval = config.getDuration("offset-store.delete-interval"),
+      acceptNewSequenceNumberAfterAge = config.getDuration("offset-store.accept-new-sequence-number-after-age"))
   }
 
   def apply(system: ActorSystem[_]): R2dbcProjectionSettings =
@@ -39,7 +40,8 @@ final case class R2dbcProjectionSettings(
     verboseLoggingEnabled: Boolean,
     timeWindow: JDuration,
     evictInterval: JDuration,
-    deleteInterval: JDuration) {
+    deleteInterval: JDuration,
+    acceptNewSequenceNumberAfterAge: JDuration) {
   val offsetTableWithSchema: String = schema.map("." + _).getOrElse("") + offsetTable
   val timestampOffsetTableWithSchema: String = schema.map("." + _).getOrElse("") + timestampOffsetTable
   val managementTableWithSchema: String = schema.map("." + _).getOrElse("") + managementTable


### PR DESCRIPTION
* Sequence number 1 and numbers that are +1 of previously known are always accepted.
* Unknown persistence id is only accepted if the age of the TimestampOffset is big enough.
* The purpose is to not emit a later sequence number for a persistence id in case
  an earlier event was missed. The backtracking query will emit events again and
  those will pass this filter.