### PR TITLE
fork tests

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -3,4 +3,3 @@
 -Xms2G
 -Xmx2G
 -Xss2M
--XX:MaxDirectMemorySize=256M

--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,8 @@ def common: Seq[Setting[_]] =
     // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
     // -a Show stack traces and exception class name for AssertionErrors.
     testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+    Test / fork := true, // some non-heap memory is leaking
+    Test / javaOptions ++= Seq("-Xms1G", "-Xmx1G", "-XX:MaxDirectMemorySize=256M"),
     projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value))
 
 lazy val dontPublish = Seq(skip in publish := true, publishArtifact in Compile := false)


### PR DESCRIPTION
* because there is some non-heap memory leak
* seems stable when running (for longer time) so something is probably not
  released when shutdown